### PR TITLE
[Feature #157723510] add admin disappprove request

### DIFF
--- a/server/src/controllers/adminController.js
+++ b/server/src/controllers/adminController.js
@@ -83,13 +83,33 @@ export default class adminController {
       });
   }
   /**
-   * This method makes a user admin.
+   * This method approves a request when called by an admin.
    * @param {Object} req - client request Object
    * @param {Object} res - Server response Object
    * @returns {Object} user
    */
   static approveRequest(req, res) {
     const requestStatus = 'approved';
+    adminController.verifyIfAdmin(req, res, requestStatus);
+  }
+  /**
+   * This method disapproves a request when called by an admin.
+   * @param {Object} req - client request Object
+   * @param {Object} res - Server response Object
+   * @returns {Object} user
+   */
+  static disapproveRequest(req, res) {
+    const requestStatus = 'disapproved';
+    adminController.verifyIfAdmin(req, res, requestStatus);
+  }
+  /**
+   * This method verifies if a user is admin.
+   * @param {Object} req - client request Object
+   * @param {Object} res - server response Object
+   * @param {String} requestStatus - new status of request
+   * @returns {Object} nothing
+   */
+  static verifyIfAdmin(req, res, requestStatus) {
     let flag = false;
     pool.connect()
       .then((client) => {
@@ -97,7 +117,9 @@ export default class adminController {
           .then((result) => {
             client.release();
             if (!result.rows[0]) return res.status(404).json({ message: 'Request not found' });
-            if (result.rows[0].status !== 'pending') return res.status(403).json({ message: 'Request has been acted upon' });
+            if (requestStatus === 'approved') {
+              if (result.rows[0].status !== 'pending') return res.status(403).json({ message: 'Request has been acted upon' });
+            }
             pool.connect()
               .then((client1) => {
                 return client1.query('SELECT * FROM users WHERE role=$1', ['admin'])

--- a/server/src/routes/adminRoute.js
+++ b/server/src/routes/adminRoute.js
@@ -11,5 +11,7 @@ adminRoute.route('/requests')
   .get(auth, adminController.getAll);
 adminRoute.route('/requests/:requestId/approve')
   .put(auth, adminController.approveRequest);
+adminRoute.route('/requests/:requestId/disapprove')
+  .put(auth, adminController.disapproveRequest);
 
 export default adminRoute;

--- a/server/src/tests/adminDisapprove.js
+++ b/server/src/tests/adminDisapprove.js
@@ -1,0 +1,20 @@
+import chai, { assert } from 'chai';
+import chaiHttp from 'chai-http';
+import adminRoute from '../routes/adminRoute';
+
+chai.should();
+chai.use(chaiHttp);
+const adminDisapprove = () => {
+  describe('/PUT', () => {
+    it('It should disapprove a pending request', (done) => {
+      chai.request(adminRoute)
+        .put('/requests/7/disapprove')
+        .end((err, res) => {
+          res.should.have.status(200);
+          assert.equal(res.body.message, 'Request disapproved');
+          done();
+        });
+    });
+  });
+};
+export default adminDisapprove;

--- a/server/src/tests/index.js
+++ b/server/src/tests/index.js
@@ -8,6 +8,7 @@ import createUser from './createUser';
 import loginUser from './loginUser';
 import adminGetAll from './adminGetAll';
 import adminApprove from './adminApprove';
+import adminDisapprove from './adminDisapprove';
 
 dotenv.config();
 chai.should();
@@ -18,6 +19,7 @@ describe('Test for Request API endpoints', () => {
   postRequest();
   updateRequest();
   adminApprove();
+  adminDisapprove();
   createUser();
   adminGetAll();
 });


### PR DESCRIPTION
#### What does this PR do?
has admin disapprove request feature
#### Description of Task to be completed?
has these endpoints working and secured:
- GET /api/v1/users/requests
- GET /api/v1/users/requests/<requestId>
- POST  /api/v1/users/requests
- PUT /api/v1/users/requests/<requestId>
- POST /api/v1/auth/signup
- POST /api/v1/auth/login
- GET /api/v1/requests
- PUT /api/v1/requests/<requestId>/approve
- PUT /api/v1/requests/<requestId>/disapprove
#### How should this be manually tested?
- Clone the repo and run "start:dev" script
- test endpoint with postman
- or check the continuous integration badge in the readme
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/157723510